### PR TITLE
Test changing up order of packs/queries in config file

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,10 +1,10 @@
 name: "My CodeQL config"
 
-packs:
-  - codeql/misra-cpp-coding-standards
-  
 queries:
   - uses: security-extended
+
+packs:
+  - codeql/misra-cpp-coding-standards
 query-filters:
   - exclude:
       id: cpp/misra/identifiers-used-in-the-controlling-expression-of

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,12 +2,9 @@ name: "My CodeQL config"
 
 packs:
   - codeql/misra-cpp-coding-standards
-
-
+  
 queries:
   - uses: security-extended
-
-
 query-filters:
   - exclude:
       id: cpp/misra/identifiers-used-in-the-controlling-expression-of

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,10 +1,12 @@
 name: "My CodeQL config"
 
+packs:
+  - codeql/misra-cpp-coding-standards
+
+
 queries:
   - uses: security-extended
 
-packs:
-  - codeql/misra-cpp-coding-standards
 
 query-filters:
   - exclude:


### PR DESCRIPTION
Confirmed - order doesnt matter here

only running 182 queries before and after this change (was 183 without the excluded query)

https://github.com/octoana/SimpleCPlusPlus/actions/runs/15496717431/job/43635077062?pr=3#step:5:71
```
  [1/182] Loaded
```